### PR TITLE
Fix segfault on g++ due to undefined behavior

### DIFF
--- a/NoBuS/ti_core.cpp
+++ b/NoBuS/ti_core.cpp
@@ -907,7 +907,7 @@ struct wlan_result simulate_wlan(const int bw, int nRAStas, int mcs) {
 						std::vector<int>::iterator temp;
 						temp = find (stas_dl.begin(), stas_dl.end(), it->second);
 						if (temp!=stas_dl.end()){
-							dl_sampleCount.erase(it);
+							it = dl_sampleCount.erase(it);
 						} else {
 							it++;
 						}
@@ -1062,7 +1062,7 @@ struct wlan_result simulate_wlan(const int bw, int nRAStas, int mcs) {
 							std::vector<int>::iterator temp;
 							temp = find (stas_ul.begin(), stas_ul.end(), it->second);
 							if (temp!=stas_ul.end()){
-								ul_sampleCount.erase(it);
+								it = ul_sampleCount.erase(it);
 							} else {
 								it++;
 							}

--- a/NoBuS/ti_core.cpp
+++ b/NoBuS/ti_core.cpp
@@ -903,11 +903,13 @@ struct wlan_result simulate_wlan(const int bw, int nRAStas, int mcs) {
 					}
 
 					// remove sent STAs and go back to DL_OFDMA after first batch if time left
-					for (auto it=dl_sampleCount.begin(); it!=dl_sampleCount.end(); ++it){
+					for (auto it=dl_sampleCount.begin(); it!=dl_sampleCount.end(); ){
 						std::vector<int>::iterator temp;
 						temp = find (stas_dl.begin(), stas_dl.end(), it->second);
 						if (temp!=stas_dl.end()){
 							dl_sampleCount.erase(it);
+						} else {
+							it++;
 						}
 					}
 					stas_dl.clear();
@@ -1056,11 +1058,13 @@ struct wlan_result simulate_wlan(const int bw, int nRAStas, int mcs) {
 						}
 
 						// remove sent STAs and go back to DL_OFDMA after first batch if time left
-						for (auto it=ul_sampleCount.begin(); it!=ul_sampleCount.end(); ++it){
+						for (auto it=ul_sampleCount.begin(); it!=ul_sampleCount.end(); ){
 							std::vector<int>::iterator temp;
 							temp = find (stas_ul.begin(), stas_ul.end(), it->second);
 							if (temp!=stas_ul.end()){
 								ul_sampleCount.erase(it);
+							} else {
+								it++;
 							}
 						}
 						stas_ul.clear();

--- a/Vanilla-WiFi7/ti_core.cpp
+++ b/Vanilla-WiFi7/ti_core.cpp
@@ -955,14 +955,14 @@ struct wlan_result simulate_wlan(const int bw, int nRAStas, int mcs) {
 						}
 					}
 
-
-
 					// remove sent STAs and go back to DL_OFDMA after first batch if time left
-					for (auto it=dl_sampleCount.begin(); it!=dl_sampleCount.end(); ++it){
+					for (auto it=dl_sampleCount.begin(); it!=dl_sampleCount.end(); ){
 						std::vector<int>::iterator temp;
 						temp = find (stas_dl.begin(), stas_dl.end(), it->second);
 						if (temp!=stas_dl.end()){
-							dl_sampleCount.erase(it);
+							it = dl_sampleCount.erase(it); // FIXME: erase invalidates it, resulting in undefined behavior when performing ++it
+						} else {
+							++it;
 						}
 					}
 					stas_dl.clear();
@@ -1168,11 +1168,13 @@ struct wlan_result simulate_wlan(const int bw, int nRAStas, int mcs) {
 						}
 
 						// remove sent STAs and go back to DL_OFDMA after first batch if time left
-						for (auto it=ul_sampleCount.begin(); it!=ul_sampleCount.end(); ++it){
+						for (auto it=ul_sampleCount.begin(); it!=ul_sampleCount.end(); ){
 							std::vector<int>::iterator temp;
 							temp = find (stas_ul.begin(), stas_ul.end(), it->second);
 							if (temp!=stas_ul.end()){
-								ul_sampleCount.erase(it);
+								it = ul_sampleCount.erase(it);
+							} else {
+								it++;
 							}
 						}
 						stas_ul.clear();

--- a/Vanilla-WiFi7/ti_core.cpp
+++ b/Vanilla-WiFi7/ti_core.cpp
@@ -960,7 +960,7 @@ struct wlan_result simulate_wlan(const int bw, int nRAStas, int mcs) {
 						std::vector<int>::iterator temp;
 						temp = find (stas_dl.begin(), stas_dl.end(), it->second);
 						if (temp!=stas_dl.end()){
-							it = dl_sampleCount.erase(it); // FIXME: erase invalidates it, resulting in undefined behavior when performing ++it
+							it = dl_sampleCount.erase(it);
 						} else {
 							++it;
 						}


### PR DESCRIPTION
Erase invalidates the iterator it is called on.
This resulted in an invalid iterator being incremented in the loop header, causing undefined behavior, such as a segfault on g++.